### PR TITLE
Lblanco initial considerations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ build-iPhoneSimulator/
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
 Gemfile.lock
+*sample_spec*

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--format documentation
+--exclude spec/**/*sample_spec*

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gem 'serverspec', '~> 2.42.3'
 gem 'highline'
 gem 'colorize'
+gem "rake"

--- a/README.md
+++ b/README.md
@@ -34,3 +34,20 @@ To view the list of available Rake tasks, use the following command:
 rake -T
 ```
 
+## Developing tests
+
+On creating a new test, is important to follow the Rakefile structure as the directory structure.
+
+Directory structure:
+
+└── spec/
+    ├── spec_helper.rb
+    │
+    ├── services/
+    │   ├── ... > PUT YOUR TESTS HERE
+    │
+    ├── configuration/
+    │   ├── ... > OR HERE
+    │
+    └── helpers/
+        ├── ...         

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Optional parameters:
 * TARGET_HOST: Machine where the tests will run via SSH.
 * LOGIN_USERNAME: Username for SSH connection to the test machine.
 * LOGIN_PASSWORD: Password for SSH connection to the test machine.
+* -j 10 -m: To run tests in pararell
 Example with optional parameters:
 ```
 TARGET_HOST="10.1.209.50" LOGIN_USERNAME="root" LOGIN_PASSWORD="redborder" rake spec

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,9 @@ require 'rspec/core/rake_task'
 task :default => :spec
 
 task :spec => "spec:all"
+
 namespace :spec do
+  # TODO: multiple hosts
     host = ENV['TARGET_HOST'] || '10.1.209.20'
 
     task :all => [:services, :configuration]

--- a/spec/services/ssh_spec.rb
+++ b/spec/services/ssh_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe port(22) do
+  it { should be_listening }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ set :disable_sudo, true
 set :path, '/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/sbin'
 
 # ssh setup
-host = ENV['TARGET_HOST']
+host = ENV['TARGET_HOST'] || '10.1.209.20'
 options = Net::SSH::Config.for(host)
 set :host, options[:host_name] || host
 options[:user] ||= ENV['LOGIN_USERNAME'] || 'root'


### PR DESCRIPTION
* Rake is needed to run serverspec. So I put it in the gemfile.
* In case devel wants to conserve, not accidentally push sample_spec and see an example of excluded files, see .rspec
* Readme now explains the directory structure to follow
* Premanager host is now added by default, in case not defined in the command line
* Test port 22 is open for testing and management
* FUTURE: Enable multiple hosts, to test all managers in a cluster