### PR TITLE
Add memcached_spec.rb with integration test for memcached

### DIFF
--- a/spec/services/memcached_spec.rb
+++ b/spec/services/memcached_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-set :os, family: 'redhat', release: '7', arch: 'x86_64'
+set :os, family: 'redhat', release: '9', arch: 'x86_64'
 
 describe 'Checking Memcached Service - Basic Checks' do
   # Verifies the installation of the Memcached package.

--- a/spec/services/memcached_spec.rb
+++ b/spec/services/memcached_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+set :os, family: 'redhat', release: '7', arch: 'x86_64'
+
+describe 'Checking Memcached Service - Basic Checks' do
+  # Verifies the installation of the Memcached package.
+  describe package('memcached') do
+    it { should be_installed }
+  end
+
+  # Checks the status of the Memcached service.
+  describe service('memcached') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  # Verifies the basic configuration of Memcached.
+  describe 'Configuration' do
+    describe file('/usr/lib/sysusers.d/memcached.conf') do
+      it { should exist }
+    end
+  end
+end
+
+describe 'Checking Memcached Service - Advanced Checks' do
+  # Checks network and connectivity aspects.
+  describe 'Network and Connectivity' do
+    describe port(11_211) do
+      it { should be_listening }
+    end
+  end
+
+  # Verifies the Memcached logs.
+  describe 'Memcached Logs' do
+    describe file('/var/log/memcached.log') do
+      its(:content) { should_not match(/error/i) }
+    end
+  end
+
+  # Verifies the user running the Memcached process.
+  describe 'Process User' do
+    describe command("ps aux | grep [m]emcached | awk '{print $1}'") do
+      its(:stdout) { should match(/memcach\+/) }
+    end
+  end
+end


### PR DESCRIPTION
## Update to memcached_spec.rb

This Pull Request updates the `memcached_spec.rb` file to enhance our testing approach for the Memcached service.

### Key Changes:
- The tests are now divided into two sections: **Basic Checks** and **Advanced Checks**. This structure aids in better organization and clarity.
- **Basic Checks** focus on verifying the installation and operational status of the Memcached package, including service enablement and runtime status.
- **Advanced Checks** delve into network connectivity, ensuring the appropriate port is listening, and check the integrity of Memcached logs.
- Added a specific check to confirm the user running the Memcached process, enhancing security and process management validation.
