### PR TITLE
Add Serverspec tests for MinIO service and package verification

### DIFF
--- a/spec/services/minio_spec.rb
+++ b/spec/services/minio_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+set :os, family: 'redhat', release: '9', arch: 'x86_64'
+
+packages = %w[
+  minio
+]
+
+service = 'minio'
+# Default port for MinIO is 9000, but we need to be sure in te configuration.
+port = 9000
+
+describe "Checking packages for #{service}..." do
+  packages.each do |package|
+    describe package(package) do
+      before do
+        skip("#{package} is not installed, skipping...") unless package(package).installed?
+      end
+
+      it 'is expected to be installed' do
+        expect(package(package).installed?).to be true
+      end
+    end
+  end
+end
+
+service_status = command("systemctl is-enabled #{service}").stdout
+service_status = service_status.strip
+
+if service_status == 'enabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe port(port) do
+      it { should be_listening }
+    end
+  end
+end
+
+if service_status == 'disabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should_not be_enabled }
+      it { should_not be_running }
+    end
+
+    describe port(port) do
+      it { should_not be_listening }
+    end
+  end
+end


### PR DESCRIPTION
## Merge Request for Adding MinIO Tests

This MR includes Serverspec tests for MinIO, covering:
- Package installations checks.
- Service enablement and running status.
- Port availability.

These tests ensure that MinIO's service and its dependencies are properly installed and operational. 
