### PR TITLE
test for nfacctd

### DIFF
--- a/spec/services/nfacctd_spec.rb
+++ b/spec/services/nfacctd_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+set :os, family: 'redhat', release: '9', arch: 'x86_64'
+
+service = 'nfacctd'
+port = 2100
+service_status = command("systemctl is-enabled #{service}").stdout.strip
+packages = %w[cookbook-pmacct pmacct]
+
+describe "Checking packages for #{service}..." do
+  packages.each do |package|
+    describe package(package) do
+      before do
+        skip("#{package} is not installed, skipping...") unless package(package).installed?
+      end
+
+      it 'is expected to be installed' do
+        expect(package(package).installed?).to be true
+      end
+    end
+  end
+end
+
+if service_status == 'enabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe port(port) do
+      it { should be_listening }
+    end
+  end
+end
+
+if service_status == 'disabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should_not be_enabled }
+      it { should_not be_running }
+    end
+
+    describe port(port) do
+      it { should_not be_listening }
+    end
+  end
+end
+
+describe "Checking #{service} for config file" do
+  describe file("/etc/pmacct/#{service}.conf") do
+    it { should exist }
+  end
+end


### PR DESCRIPTION
Added tests for 'nfacctd'.

- Introduced new test cases to cover 'nfacctd'.
- Ensured that the tests validate the expected packages, service, port and existence of configuration file of 'nfacctd'.