### PR TITLE
Delete the check for logs in druid-historical

### DIFF
--- a/spec/services/druid_historical_spec.rb
+++ b/spec/services/druid_historical_spec.rb
@@ -31,10 +31,6 @@ if service_status == 'enabled'
       it { should exist }
     end
 
-    describe file('/var/log/druid/historical.log') do
-      its(:content) { should_not match(/ERROR/) }
-    end
-
     it 'should be registered and healthy in Consul' do
       expect(service_registered_and_healthy?(service)).to be true
     end


### PR DESCRIPTION
## PR Summary
Removed check for ERROR logs in `/var/log/druid/historical.log`.