### PR TITLE
Add Serverspec tests for redborder-dswatcher service

### DIFF
--- a/spec/services/redborder-dswatcher_spec.rb
+++ b/spec/services/redborder-dswatcher_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+set :os, family: 'redhat', release: '9', arch: 'x86_64'
+
+service = 'redborder-dswatcher'
+service_status = command("systemctl is-enabled #{service}").stdout.strip
+packages = %w[redborder-dswatcher] 
+
+describe "Checking packages for #{service}..." do
+  packages.each do |package|
+    describe package(package) do
+      before do
+        skip("#{package} is not installed, skipping...") unless package(package).installed?
+      end
+
+      it 'is expected to be installed' do
+        expect(package(package).installed?).to be true
+      end
+    end
+  end
+end
+
+if service_status == 'enabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+  end
+end
+
+if service_status == 'disabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should_not be_enabled }
+      it { should_not be_running }
+    end
+  end
+end
+
+describe "Checking for config file of #{service}" do
+  describe file("/etc/redborder-dswatcher/config.yml") do
+    it { should exist }
+  end
+end

--- a/spec/services/redborder-dswatcher_spec.rb
+++ b/spec/services/redborder-dswatcher_spec.rb
@@ -5,7 +5,7 @@ set :os, family: 'redhat', release: '9', arch: 'x86_64'
 
 service = 'redborder-dswatcher'
 service_status = command("systemctl is-enabled #{service}").stdout.strip
-packages = %w[redborder-dswatcher] 
+packages = %w[redborder-dswatcher]
 
 describe "Checking packages for #{service}..." do
   packages.each do |package|
@@ -40,7 +40,7 @@ if service_status == 'disabled'
 end
 
 describe "Checking for config file of #{service}" do
-  describe file("/etc/redborder-dswatcher/config.yml") do
+  describe file('/etc/redborder-dswatcher/config.yml') do
     it { should exist }
   end
 end

--- a/spec/services/redborder_dswatcher_spec.rb
+++ b/spec/services/redborder_dswatcher_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+set :os, family: 'redhat', release: '9', arch: 'x86_64'
+
+service = 'redborder-dswatcher'
+service_status = command("systemctl is-enabled #{service}").stdout.strip
+packages = %w[redborder-dswatcher]
+
+describe "Checking packages for #{service}..." do
+  packages.each do |package|
+    describe package(package) do
+      before do
+        skip("#{package} is not installed, skipping...") unless package(package).installed?
+      end
+
+      it 'is expected to be installed' do
+        expect(package(package).installed?).to be true
+      end
+    end
+  end
+end
+
+if service_status == 'enabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+  end
+end
+
+if service_status == 'disabled'
+  describe "Checking #{service_status} service for #{service}..." do
+    describe service(service) do
+      it { should_not be_enabled }
+      it { should_not be_running }
+    end
+  end
+end
+
+describe "Checking for config file of #{service}" do
+  describe file('/etc/redborder-dswatcher/config.yml') do
+    it { should exist }
+  end
+end


### PR DESCRIPTION
**Pull Request Overview:**

1. **Package Verification:** Checks if `redborder-dswatcher` package is installed.
2. **Service Status:** Validates that the service is both enabled and active.
3. **Config File Check:** Confirms the existence of `/etc/redborder-dswatcher/config.yml`.