### PR TITLE
Improvement/check ipv4

### DIFF
--- a/spec/configuration/network_spec.rb
+++ b/spec/configuration/network_spec.rb
@@ -30,7 +30,7 @@ end
 describe 'Sync network' do
   sync = command('ip addr show').stdout
   it 'Have a network sync' do
-    interfaces_with_ip = sync.scan(/inet\s+(\d+\.\d+\.\d+\.\d+)/).flatten
+    interfaces_with_ip = sync.scan(/inet\s+(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/).flatten
     expect(interfaces_with_ip.length).to be >= 3
     puts "OUTPUT: #{interfaces_with_ip}"
   end

--- a/spec/configuration/network_spec.rb
+++ b/spec/configuration/network_spec.rb
@@ -22,7 +22,7 @@ puts "HOST: #{ip}"
 
 describe 'Management network' do
   it 'The Management network should contain an IP' do
-    expect(ip).to match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
+    expect(ip).to match(/\A(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\z/)
   end
 end
 


### PR DESCRIPTION
Better regex to check the ips are IPv4, not any 4 dotted number.
Ie.
Now 1000.1002.1003.1004 will not match as a valid ip