### PR TITLE
IS_CLUSTER as env param to skip sync interface and number of nodes

### DIFF
--- a/spec/configuration/network_spec.rb
+++ b/spec/configuration/network_spec.rb
@@ -31,7 +31,11 @@ describe 'Sync network' do
   sync = command('ip addr show').stdout
   it 'Have a network sync' do
     interfaces_with_ip = sync.scan(/inet\s+(\d+\.\d+\.\d+\.\d+)/).flatten
-    expect(interfaces_with_ip.length).to be >= 3
+    if ENV['IS_CLUSTER']
+      expect(interfaces_with_ip.length).to be >= 3
+    else
+      skip 'One node does not need sync interface'
+    end
     puts "OUTPUT: #{interfaces_with_ip}"
   end
 end
@@ -65,6 +69,10 @@ end
 describe 'IPMI' do
   ipmi_status = command('rpm -qa | grep ipmi').stdout
   it 'Status IPMI' do
-    expect(ipmi_status).to include('ipmi')
+    if ENV['IS_CLUSTER']
+      expect(ipmi_status).to include('ipmi')
+    else
+      skip 'One node does not need IPMI'
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,11 @@ require 'tempfile'
 set :backend, :ssh
 set :disable_sudo, true
 
+# spec/spec_helper.rb
+
+# Check if IS_CLUSTER environment variable is already set
+ENV['IS_CLUSTER'] ||= 'true' unless ENV.key?('IS_CLUSTER') && ENV['IS_CLUSTER'] == 'false'
+
 # ssh setup
 host = ENV['TARGET_HOST'] || '10.1.209.20'
 options = Net::SSH::Config.for(host)
@@ -18,5 +23,4 @@ options[:password] = if ENV['ASK_LOGIN_PASSWORD']
                      else
                        ENV['LOGIN_PASSWORD'] || 'redborder'
                      end
-
 set :ssh_options, options


### PR DESCRIPTION
Some of the tests are failing because I'm testing with serverspec in an alone manager, not a full cluster. I put a env variable to explicitly say this is not a cluster. Like we do with TARGET_HOST=<ip>, now we can say IS_CLUSTER='false'

I suppose a better solution should be to identifiy if we are in a single node or in a cluster and run tests depending on the case