### PR TITLE
Bugfix/#16953 test journalctl checking no load error

### DIFF
--- a/spec/services/chef_spec.rb
+++ b/spec/services/chef_spec.rb
@@ -80,7 +80,7 @@ if service_status == 'disabled'
   end
 end
 
-describe command("journalctl -u #{service}"), :chef_journal do
+describe command("journalctl -u #{service} | awk '/LoadError/ {print; exit}'"), :chef_journal do
   its('exit_status') { should eq 0 }
   its('stdout') { should_not match(/LoadError/) }
 end

--- a/spec/services/chef_spec.rb
+++ b/spec/services/chef_spec.rb
@@ -79,3 +79,8 @@ if service_status == 'disabled'
     end
   end
 end
+
+describe command("journalctl -u #{service}"), :chef_journal do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should_not match(/LoadError/) }
+end


### PR DESCRIPTION
Test to check if journal has LoadError about chef. This is useful because some ruby modules need it, like redborder-cgroups. However, keep in mind this kind of tests can expend too much time. In this case, it's reading the whole journal of service chef-client